### PR TITLE
Enable static serving even with gunicorn

### DIFF
--- a/comptest/comptest/urls.py
+++ b/comptest/comptest/urls.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path
 from web.views.socialaccount import CustomLoginView
-from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 urlpatterns = [
     path("", include("web.urls")),

--- a/comptest/comptest/urls.py
+++ b/comptest/comptest/urls.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.urls import include, path
 from web.views.socialaccount import CustomLoginView
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 
 urlpatterns = [
     path("", include("web.urls")),
@@ -8,3 +9,6 @@ urlpatterns = [
     path("accounts/login/", CustomLoginView.as_view(), name="account_login"),
     path("accounts/", include("allauth.urls")),
 ]
+
+# Enable static serving even with external webserver like gunicorn
+urlpatterns += staticfiles_urlpatterns()


### PR DESCRIPTION
Will be eventually replaced with something more optimized

Ref https://github.com/2i2c-org/unnamed-thingity-thing/issues/59