### PR TITLE
Serve uploaded media files with nginx, not django/gunicorn

### DIFF
--- a/comptest/comptest/urls.py
+++ b/comptest/comptest/urls.py
@@ -1,10 +1,9 @@
+from django.conf import settings
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path
 from web.views.socialaccount import CustomLoginView
-from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-from django.conf import settings
-from django.conf.urls.static import static
 
 urlpatterns = [
     path("", include("web.urls")),

--- a/comptest/comptest/urls.py
+++ b/comptest/comptest/urls.py
@@ -1,9 +1,10 @@
-from django.conf import settings
-from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path
 from web.views.socialaccount import CustomLoginView
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
     path("", include("web.urls")),
@@ -15,4 +16,7 @@ urlpatterns = [
 # Enable static serving even with external webserver like gunicorn
 urlpatterns += staticfiles_urlpatterns()
 
-urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+# Serve media URLs only when running as debug mode
+# nginx should serve them for us otherwise
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -60,14 +60,10 @@ spec:
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           workingDir: /opt/unnamed-thingity-thing/comptest
-          ports:
-            - name: http
-              containerPort: {{ .Values.service.port }}
-              protocol: TCP
           command:
             - gunicorn
             - --bind
-            - 0.0.0.0:{{ .Values.service.port }}
+            - 127.0.0.1:8000
             - comptest.wsgi
           securityContext:
             runAsUser: 0
@@ -77,6 +73,20 @@ spec:
             - name: django-yamlconf
               mountPath: /opt/unnamed-thingity-thing/comptest/comptest.yaml
               subPath: comptest.yaml
+        - name: nginx
+          image: nginx:1.27
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: storage
+              mountPath: /opt/state
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
       volumes:
         - name: storage
           persistentVolumeClaim:
@@ -84,3 +94,6 @@ spec:
         - name: django-yamlconf
           configMap:
             name: {{ include "unnamed.fullname" . }}-django-yamlconf
+        - name: nginx-config
+          configMap:
+            name: {{ include "unnamed.fullname" . }}-nginx

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -21,7 +21,7 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 8000
+  port: 80
 
 ingress:
   enabled: false


### PR DESCRIPTION
- Is recommended by django for production instances (https://docs.gunicorn.org/en/latest/deploy.html)
- Probably faster
- Allows for future finetuning as needed
- Does not actually change the *static* files - only the media files for now. Static files are in the django deployment image and more work.
- The challenge is serving .glb files that are >10Mb, so the nginx improvement is worth it.

Ref https://github.com/2i2c-org/unnamed-thingity-thing/issues/59