### PR TITLE
Increase the upload size limit of nginx

### DIFF
--- a/helm-chart/templates/configmap-nginx.yaml
+++ b/helm-chart/templates/configmap-nginx.yaml
@@ -7,6 +7,9 @@ data:
     server {
         listen {{ .Values.service.port }};
 
+        # Increase the limit of
+        client_max_body_size 1024m;
+
         location /media/ {
           alias /opt/state/media/;
 


### PR DESCRIPTION
It defaults to 1m, so we can't upload our glb files.

Ref https://github.com/2i2c-org/unnamed-thingity-thing/issues/59