### PR TITLE
Add site-specific settings (logo, title)

### DIFF
--- a/comptest/comptest/settings.py
+++ b/comptest/comptest/settings.py
@@ -74,7 +74,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "web.context_processors.navbar_pages",
-                "web.context_processors.footer_content",
+                "web.context_processors.site_display_settings",
             ],
         },
     },
@@ -197,18 +197,6 @@ SOCIALACCOUNT_LOGIN_ON_GET = True
 # Based on this, different views are shown to the user
 CHALLENGE_STATE = "RUNNING"
 
-FOOTER = """
-<div class="footer">
-    <p id="footer-text">&copy; HELLO!</p>
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            var footerText = document.getElementById('footer-text');
-            var timeOfDay = new Date().toString();
-            footerText.innerHTML = timeOfDay;
-        });
-    </script>
-</div>
-"""
 
 import os
 
@@ -228,6 +216,15 @@ if not output_dir.endswith("/"):
 os.makedirs(output_dir, exist_ok=True)
 
 UNNAMED_THINGY_EVALUATOR_OUTPUTS_TEMPDIR = output_dir
+
+## Site specific display settings
+SITE_NAME = "Unnamed thingity thingy"
+SITE_LOGO_URL = ""
+SITE_FOOTER_HTML = """
+<div class="footer">
+    <p>Change this to your custom footer</p>
+</div>
+"""
 
 django_yamlconf.load()
 django_yamlconf.list_attrs()

--- a/comptest/web/context_processors.py
+++ b/comptest/web/context_processors.py
@@ -8,5 +8,9 @@ def navbar_pages(request):
     return {"pages": pages}
 
 
-def footer_content(request):
-    return {"footer": settings.FOOTER}
+def site_display_settings(request):
+    return {
+        "site_name": settings.SITE_NAME,
+        "site_logo_url": settings.SITE_LOGO_URL,
+        "site_footer_html": settings.SITE_FOOTER_HTML
+    }

--- a/comptest/web/context_processors.py
+++ b/comptest/web/context_processors.py
@@ -12,5 +12,5 @@ def site_display_settings(request):
     return {
         "site_name": settings.SITE_NAME,
         "site_logo_url": settings.SITE_LOGO_URL,
-        "site_footer_html": settings.SITE_FOOTER_HTML
+        "site_footer_html": settings.SITE_FOOTER_HTML,
     }

--- a/comptest/web/templates/page.html
+++ b/comptest/web/templates/page.html
@@ -5,14 +5,22 @@
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link href='{% static "webpack-output/main.css" %}' rel="stylesheet" />
-        <title>Unnamed Competitive Tester</title>
+        {% block title %}
+        <title>{{site_name}}</title>
+        {% endblock title %}
         {% block head %}
         {% endblock head %}
     </head>
     <body>
-        <nav class="navbar navbar-expand-lg bg-body-tertiary">
+        <nav class="navbar navbar-expand-lg">
             <div class="container">
-                <a class="navbar-brand" href="/">Unnamed Competitive Tester</a>
+                <a class="navbar-brand" href="/">
+                    {% if site_logo_url %}
+                    <img src="{{site_logo_url}}" title="{{site_name}}" height="32px" />
+                    {% else %}
+                    {{site_name}}
+                    {% endif %}
+                </a>
                 <div class="collapse navbar-collapse">
                     <div class="navbar-nav">
                         {% for p in pages %}
@@ -54,13 +62,6 @@
         </div>
     </body>
     <footer>
-        <nav class="navbar navbar-expand-lg bg-body-tertiary">
-            <div class="container">
-                <!-- <a class="navbar-brand" href="/"></a> -->
-                <div class="collapse navbar-collapse">
-                    <div class="navbar-nav">{{ footer|safe }}</div>
-                </div>
-            </div>
-        </nav>
+        {{ site_footer_html|safe }}
     </footer>
 </html>

--- a/comptest/web/templates/page.html
+++ b/comptest/web/templates/page.html
@@ -14,9 +14,9 @@
     <body>
         <nav class="navbar navbar-expand-lg">
             <div class="container">
-                <a class="navbar-brand" href="/">
+                <a class="navbar-brand" href="/" title="{{ site_name }}">
                     {% if site_logo_url %}
-                        <img src="{{ site_logo_url }}" title="{{ site_name }}" height="32px" />
+                        <img src="{{ site_logo_url }}" alt="{{ site_name }}" height="32px" width="auto"/>
                     {% else %}
                         {{ site_name }}
                     {% endif %}

--- a/comptest/web/templates/page.html
+++ b/comptest/web/templates/page.html
@@ -6,7 +6,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link href='{% static "webpack-output/main.css" %}' rel="stylesheet" />
         {% block title %}
-        <title>{{site_name}}</title>
+            <title>{{ site_name }}</title>
         {% endblock title %}
         {% block head %}
         {% endblock head %}
@@ -16,9 +16,9 @@
             <div class="container">
                 <a class="navbar-brand" href="/">
                     {% if site_logo_url %}
-                    <img src="{{site_logo_url}}" title="{{site_name}}" height="32px" />
+                        <img src="{{ site_logo_url }}" title="{{ site_name }}" height="32px" />
                     {% else %}
-                    {{site_name}}
+                        {{ site_name }}
                     {% endif %}
                 </a>
                 <div class="collapse navbar-collapse">

--- a/comptest/web/templates/page.html
+++ b/comptest/web/templates/page.html
@@ -16,7 +16,10 @@
             <div class="container">
                 <a class="navbar-brand" href="/" title="{{ site_name }}">
                     {% if site_logo_url %}
-                        <img src="{{ site_logo_url }}" alt="{{ site_name }}" height="32px" width="auto"/>
+                        <img src="{{ site_logo_url }}"
+                             alt="{{ site_name }}"
+                             height="32px"
+                             width="auto" />
                     {% else %}
                         {{ site_name }}
                     {% endif %}

--- a/comptest/web/templates/page/view.html
+++ b/comptest/web/templates/page/view.html
@@ -1,6 +1,8 @@
 {% extends "page.html" %}
 {% block title %}
-<title>{% if not page.is_home  %}{{ page.title|title }} - {% endif %}{{site_name}}</title>
+    <title>
+        {% if not page.is_home %}{{ page.title|title }} -{% endif %}
+    {{ site_name }}</title>
 {% endblock title %}
 {% block body %}
     {{ html_content|safe }}

--- a/comptest/web/templates/page/view.html
+++ b/comptest/web/templates/page/view.html
@@ -1,4 +1,7 @@
 {% extends "page.html" %}
+{% block title %}
+<title>{% if not page.is_home  %}{{ page.title|title }} - {% endif %}{{site_name}}</title>
+{% endblock title %}
 {% block body %}
     {{ html_content|safe }}
 {% endblock body %}


### PR DESCRIPTION
- Move footer setting to match new site setting naming patterns.
- Use site name in title
- Don't show "Home" for the home page, only site title

Ref https://github.com/2i2c-org/unnamed-thingity-thing/issues/59