### PR TITLE
Use mustToJson to write out YAML in configmap

### DIFF
--- a/helm-chart/templates/configmap-yamlconf.yaml
+++ b/helm-chart/templates/configmap-yamlconf.yaml
@@ -3,5 +3,5 @@ kind: ConfigMap
 metadata:
   name: {{ include "unnamed.fullname" . }}-django-yamlconf
 data:
-  comptest.yaml: |-
-{{- include "unnamed.toYamlRecursive" .Values.yamlSettings.overrides | indent 2 }}
+  comptest.yaml: |
+    {{ mustToJson .Values.yamlSettings.overrides }}


### PR DESCRIPTION
Otherwise, we had a slightly homegrown toYaml implementation that was throwing errors on multiline config