### PR TITLE
Trigger rollout when any either configmap changes

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -14,10 +14,13 @@ spec:
       {{- include "unnamed.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- /* changed configmap checksums -> changed pod template -> triggers rollout */}}
+        checksum/configmap-nginx: {{ include (print .Template.BasePath "/configmap-nginx.yaml") . | sha256sum }}
+        checksum/configmap-yamlconf: {{ include (print .Template.BasePath "/configmap-yamlconf.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- . | nindent 8 | toYaml }}
+        {{- end }}
       labels:
         {{- include "unnamed.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
- fixes #68

---

I've not deployed this or similar, but I've tested that the helm chart renders as intended with `helm template .`, showing new annotations with checksums.

I've concluded that nginx needs an active restart/reload to adjust to a changed configmap, so restarting the pod makes sense when the nginx configmap changes - something that I wasn't confident on.