### PR TITLE
Don't specify hostPort for dind

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -118,11 +118,6 @@ spec:
           command:
             - dockerd
             - --host=tcp://127.0.0.1:2376
-          ports:
-            - name: dind-port
-              containerPort: 2376
-              hostPort: 2376
-              protocol: TCP
           securityContext:
             privileged: true
         - name: nginx


### PR DESCRIPTION
When using multiple containers in the same pod, they already share localhost as the same interface without any additional work (see https://kubernetes.io/docs/concepts/workloads/pods/#pod-networking).

If we set hostPort, only one pod containing that hostPort can be on that one node. This was causing issues with prod and staging pod being on the same node, with the following error:

>   Warning  FailedScheduling   82s (x3 over 6m41s)   default-scheduler   0/1
> nodes are available: 1 node(s) didn't have free ports for the requested pod
> ports. preemption: 0/1 nodes are available: 1 No preemption victims found for
> incoming pod.

This triggered a short outage, as staging kicked out the prod pod.

Ref https://github.com/2i2c-org/unnamed-thingity-thing/issues/25