### PR TITLE
Rm logging of db queries results

### DIFF
--- a/comptest/web/management/commands/evaluator.py
+++ b/comptest/web/management/commands/evaluator.py
@@ -137,7 +137,6 @@ class Command(BaseCommand):
             unstarted_evaluations = Evaluation.objects.select_related(
                 "submission"
             ).filter(status=Evaluation.Status.NOT_STARTED)
-            logger.debug(f"Unstarted evaluations: {unstarted_evaluations}")
 
             async for e in unstarted_evaluations:
                 await self.start_evaluation(evaluator, e)
@@ -146,7 +145,6 @@ class Command(BaseCommand):
             running_evaluations = Evaluation.objects.select_related(
                 "submission"
             ).filter(status=Evaluation.Status.EVALUATING)
-            logger.debug(f"Running evaluations: {running_evaluations}")
 
             async for e in running_evaluations:
                 await self.process_running_evaluation(evaluator, e)


### PR DESCRIPTION
These are generating the following errors about sync and async contexts that will solve if we really need to log these. For now, just rm them. 

```
  File "/usr/local/lib/python3.12/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.12/site-packages/django/core/management/base.py", line 413, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python3.12/site-packages/django/core/management/base.py", line 459, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/unnamed-thingity-thing/comptest/web/management/commands/evaluator.py", line 157, in handle
    asyncio.run(self.ahandle())
  File "/usr/local/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/opt/unnamed-thingity-thing/comptest/web/management/commands/evaluator.py", line 140, in ahandle
    logger.debug(f"Unstarted evaluations: {unstarted_evaluations}")
                                          ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/db/models/query.py", line 376, in __repr__
    data = list(self[: REPR_OUTPUT_SIZE + 1])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/db/models/query.py", line 400, in __iter__
    self._fetch_all()
  File "/usr/local/lib/python3.12/site-packages/django/db/models/query.py", line 1928, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/db/models/query.py", line 91, in __iter__
    results = compiler.execute_sql(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/db/models/sql/compiler.py", line 1572, in execute_sql
    cursor = self.connection.cursor()
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/django/utils/asyncio.py", line 24, in inner
    raise SynchronousOnlyOperation(message)
django.core.exceptions.SynchronousOnlyOperation: You cannot call this from an async context - use a thread or sync_to_async.
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7d67b8c056d0>
```