### PR TITLE
Make evaluator more configurable

### DIFF
--- a/comptest/comptest/settings.py
+++ b/comptest/comptest/settings.py
@@ -216,6 +216,12 @@ if not output_dir.endswith("/"):
 os.makedirs(output_dir, exist_ok=True)
 
 UNNAMED_THINGY_EVALUATOR_OUTPUTS_TEMPDIR = output_dir
+EVALUATOR_DOCKER_IMAGE = "quay.io/yuvipanda/evaluator-harness:latest"
+EVALUATOR_DOCKER_CMD = [
+]
+
+EVALUATOR_DOCKER_EXTRA_BINDS = [
+]
 
 ## Site specific display settings
 SITE_NAME = "Unnamed thingity thingy"


### PR DESCRIPTION
- Configure the image to be used by the evaluator
- Configure the command run by the evaluator
- Configure any additional bind mounts to be made available to the evaluator

Fixes https://github.com/2i2c-org/unnamed-thingity-thing/issues/111 Fixes https://github.com/2i2c-org/unnamed-thingity-thing/issues/110