### PR TITLE
Make sure submissions and results are in shared dir

### DIFF
--- a/comptest/comptest/settings.py
+++ b/comptest/comptest/settings.py
@@ -207,21 +207,12 @@ CHALLENGE_STATE = "RUNNING"
 import os
 
 out_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "uploads/"))
-if not out_dir.endswith("/"):
-    out_dir += "/"
-os.makedirs(out_dir, exist_ok=True)
 
-UNNAMED_THINGY_UPLOADS_DIR = out_dir
+SUBMISSIONS_UPLOADS_DIR = out_dir
 
-# Make a local directory for containing outputs if needed
-# FIXME: Move this somewhere else or make this configurable
-# This *must* be bind mountable into the docker container
 output_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "outputs/"))
-if not output_dir.endswith("/"):
-    output_dir += "/"
-os.makedirs(output_dir, exist_ok=True)
+SUBMISSIONS_RESULTS_DIR = output_dir
 
-UNNAMED_THINGY_EVALUATOR_OUTPUTS_TEMPDIR = output_dir
 EVALUATOR_DOCKER_IMAGE = "quay.io/yuvipanda/evaluator-harness:latest"
 EVALUATOR_DOCKER_CMD = []
 

--- a/comptest/web/management/commands/evaluator.py
+++ b/comptest/web/management/commands/evaluator.py
@@ -30,8 +30,9 @@ class DockerEvaluator:
     async def start_evaluation(self, input_uri):
         await self.pull_image()
 
+        os.makedirs(settings.SUBMISSIONS_RESULTS_DIR, exist_ok=True)
         results_dir = tempfile.mkdtemp(
-            prefix=settings.UNNAMED_THINGY_EVALUATOR_OUTPUTS_TEMPDIR
+            prefix=settings.SUBMISSIONS_RESULTS_DIR
         )
         results_file = os.path.join(results_dir, "output.json")
         results_uri = f"file://{results_file}"

--- a/comptest/web/management/commands/evaluator.py
+++ b/comptest/web/management/commands/evaluator.py
@@ -31,9 +31,7 @@ class DockerEvaluator:
         await self.pull_image()
 
         os.makedirs(settings.SUBMISSIONS_RESULTS_DIR, exist_ok=True)
-        results_dir = tempfile.mkdtemp(
-            prefix=settings.SUBMISSIONS_RESULTS_DIR
-        )
+        results_dir = tempfile.mkdtemp(prefix=settings.SUBMISSIONS_RESULTS_DIR)
         results_file = os.path.join(results_dir, "output.json")
         results_uri = f"file://{results_file}"
 

--- a/comptest/web/views/default.py
+++ b/comptest/web/views/default.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 
 from django import forms
@@ -18,7 +19,10 @@ def upload(request: HttpRequest) -> HttpResponse:
     if request.method == "POST":
         form = UploadForm(request.POST, request.FILES)
         if form.is_valid():
-            _, filepath = tempfile.mkstemp(prefix=settings.UNNAMED_THINGY_UPLOADS_DIR)
+            # FIXME: We are creating the uploads directory on first use if
+            # necessary. This may be a security risk, let's verify.
+            os.makedirs(settings.SUBMISSIONS_UPLOADS_DIR, exist_ok=True)
+            _, filepath = tempfile.mkstemp(prefix=settings.SUBMISSIONS_UPLOADS_DIR)
             with open(filepath, "wb") as f:
                 f.write(request.FILES["file"].read())
             s = Submission(

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -118,6 +118,9 @@ spec:
           command:
             - dockerd
             - --host=tcp://127.0.0.1:2376
+          volumeMounts:
+            - name: storage
+              mountPath: /opt/state
           securityContext:
             privileged: true
         - name: nginx

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -50,6 +50,8 @@ yamlSettings:
     MEDIA_ROOT: /opt/state/media/
     STATIC_ROOT: /opt/staticfiles/
     DATABASES.default.NAME: /opt/state/db.sqlite3
+    SUBMISSIONS_UPLOADS_DIR: /opt/state/submissions/
+    SUBMISSIONS_RESULTS_DIR: /opt/state/submission-results/
 
 adminUsers: []
 


### PR DESCRIPTION
- Directory storing uploads and results must be shared between dind, evaluator and django serving container
- Rename some settings

Ref https://github.com/2i2c-org/unnamed-thingity-thing/issues/25