### PR TITLE
Redirect to leaderboard, not /home, after submission

### DIFF
--- a/comptest/web/views/default.py
+++ b/comptest/web/views/default.py
@@ -31,7 +31,8 @@ def upload(request: HttpRequest) -> HttpResponse:
                 data_uri=f"file:///{filepath}",
             )
             s.save()
-            return HttpResponseRedirect("/")
+            # FIXME: Redirect to viewing the currently uploaded submission instead
+            return HttpResponseRedirect("/leaderboard")
     else:
         form = UploadForm()
     return render(request, "upload.html", {"form": form})


### PR DESCRIPTION
This is a temporary fix, until we can see the submission page itself.