### PR TITLE
Add simple 'My Submissions' page

### DIFF
--- a/comptest/web/templates/page.html
+++ b/comptest/web/templates/page.html
@@ -44,6 +44,9 @@
                                 <li class="nav-item">
                                     <a class="nav-link" href="{% url 'leaderboard' %}">Leaderboard</a>
                                 </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" href="{% url 'submissions-list' %}">My Submissions</a>
+                                </li>
                             {% endif %}
                             {% if request.user.is_authenticated %}
                                 <li class="nav-item">

--- a/comptest/web/templates/results.html
+++ b/comptest/web/templates/results.html
@@ -71,7 +71,7 @@
 
       setInterval(() => {
         table.ajax.reload();
-      }, 5 * 1000);
+      }, 600 * 1000);
     }
 
     main();

--- a/comptest/web/templates/submissions.html
+++ b/comptest/web/templates/submissions.html
@@ -10,5 +10,27 @@
     <script src="https://cdn.jsdelivr.net/npm/dayjs@1/plugin/relativeTime.js"></script>
 {% endblock head %}
 {% block body %}
-    {{ submissions }}
+    <div class="container">
+        <h1>My Submissions</h1>
+    </div>
+    <div class="container">
+        <table class="table table-striped table-sm">
+            <thead>
+                <tr>
+                    <th scope="col">Last Updated</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Result</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for sub in submissions %}
+                    <tr>
+                        <td>{{ sub.last_updated }}</td>
+                        <td>{{ sub.status }}</td>
+                        <td>{{ sub.result }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
 {% endblock body %}

--- a/comptest/web/templates/submissions.html
+++ b/comptest/web/templates/submissions.html
@@ -1,0 +1,14 @@
+{% extends "page.html" %}
+{% block head %}
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"
+            integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo="
+            crossorigin="anonymous"></script>
+    <link rel="stylesheet"
+          href="https://cdn.datatables.net/2.0.8/css/dataTables.dataTables.css" />
+    <script src="https://cdn.datatables.net/2.0.8/js/dataTables.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dayjs@1/plugin/relativeTime.js"></script>
+{% endblock head %}
+{% block body %}
+    {{ submissions }}
+{% endblock body %}

--- a/comptest/web/urls.py
+++ b/comptest/web/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from .views import default, pages, teams
+from .views import default, pages, submissions, teams
 
 urlpatterns = [
     path("upload", default.upload, name="upload"),
@@ -12,5 +12,6 @@ urlpatterns = [
     path("page/<slug:slug>", pages.view, name="page-view"),
     path("file/<slug:slug>", pages.content_file, name="content-file"),
     path("leaderboard", default.leaderboard, name="leaderboard"),
+    path("submissions", submissions.list, name="submissions-list"),
     path("", pages.home, name="home"),
 ]

--- a/comptest/web/views/submissions.py
+++ b/comptest/web/views/submissions.py
@@ -1,0 +1,14 @@
+from django.contrib.auth.decorators import login_required
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+
+from ..models import Evaluation
+
+
+@login_required
+def list(request: HttpRequest) -> HttpResponse:
+    """
+    List all evaluations of the current user
+    """
+    submissions = Evaluation.objects.filter(submission__user=request.user)
+    return render(request, "submissions.html", {"submissions": submissions})


### PR DESCRIPTION
Implements a basic 'My Submissions' page so a user can explore all of their evaluated submissions.

This sets the groundwork for

- viewing group membership, project membership, etc.
- toggling which evaluated submissions are added to the leaderboard

Commit https://github.com/2i2c-org/unnamed-thingity-thing/pull/122/commits/4203aad1221d609a7594b21e0eb445a9ff1402fc also temporarily addresses #120 