### PR TITLE
evaluator: Allow specifying cpu limit & auth for docker container

### DIFF
--- a/comptest/comptest/settings.py
+++ b/comptest/comptest/settings.py
@@ -217,6 +217,17 @@ EVALUATOR_DOCKER_IMAGE = "quay.io/yuvipanda/evaluator-harness:latest"
 EVALUATOR_DOCKER_CMD = []
 
 EVALUATOR_DOCKER_EXTRA_BINDS = []
+EVALUATOR_DOCKER_AUTH = {}
+# If you want to use a GCP Artifact Registry service key, use the following config:
+# for EVALUATOR_DOCKER_AUTH
+# {
+#     "username": "_json_key",
+#     "password": open("serviceaccount.json").read(), # or path to your service account file
+#     "serveraddress": "us-west2-docker.pkg.dev" # or the host used by your artifact registry
+# }
+
+# Max number of CPUs allowed for the evaluator
+EVALUATOR_DOCKER_CONTAINER_CPU_LIMIT = 2
 
 ## Site specific display settings
 SITE_NAME = "Unnamed thingity thingy"

--- a/comptest/web/management/commands/evaluator.py
+++ b/comptest/web/management/commands/evaluator.py
@@ -67,7 +67,9 @@ class DockerEvaluator:
             # the CpuPeriod of 100000 and multiplying the CPU limit by that number, as documented
             # in https://docs.docker.com/engine/containers/resource_constraints/#configure-the-default-cfs-scheduler
             host_config["CpuPeriod"] = 100000
-            host_config["CpuQuota"] = int(settings.EVALUATOR_DOCKER_CONTAINER_CPU_LIMIT * host_config["CpuPeriod"])
+            host_config["CpuQuota"] = int(
+                settings.EVALUATOR_DOCKER_CONTAINER_CPU_LIMIT * host_config["CpuPeriod"]
+            )
         container = await self.docker.containers.create(
             config={
                 "Image": self.image,

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -94,6 +94,23 @@ spec:
             - name: django-yamlconf
               mountPath: /opt/unnamed-thingity-thing/comptest/comptest.yaml
               subPath: comptest.yaml
+        - name: dind
+          image: {{ .Values.dind.image.repository }}:{{ .Values.dind.image.tag }}
+          command:
+            {{ if .Values.dind.rootless }}
+            - dind
+            {{- end }}
+            - dockerd
+            - --host=tcp://127.0.0.1:2376
+          volumeMounts:
+            - name: storage
+              mountPath: /opt/state
+          securityContext:
+            privileged: true
+            runAsUser: 0
+          env:
+            - name: DOCKER_HOST
+              value: tcp://127.0.0.1:2376
         - name: evaluator
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -113,16 +130,6 @@ spec:
           env:
             - name: DOCKER_HOST
               value: tcp://127.0.0.1:2376
-        - name: dind
-          image: docker:27.0.3-dind
-          command:
-            - dockerd
-            - --host=tcp://127.0.0.1:2376
-          volumeMounts:
-            - name: storage
-              mountPath: /opt/state
-          securityContext:
-            privileged: true
         - name: nginx
           image: {{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}
           securityContext:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -60,3 +60,9 @@ nginx:
     repository: nginx
     tag: 1.27
   resources: {}
+
+dind:
+  rootless: false
+  image:
+    repository: docker
+    tag: 27.0.3-dind


### PR DESCRIPTION
- Allow specifying if dind should be run rootless, for use with colima or similar k8s setups that are fully rootless
- Allow configuring the image and tag used to run dind, so it can be configured to use the rootless tag when needed
- Only pull image if it doesn't already exist, to speed up local development
- Allow specifying auth, so we can pull from private repositories

Fixes https://github.com/2i2c-org/unnamed-thingity-thing/issues/125 Ref https://github.com/2i2c-org/unnamed-thingity-thing/issues/113