### PR TITLE
Disable network access from inside the evaluation container

### DIFF
--- a/comptest/comptest/settings.py
+++ b/comptest/comptest/settings.py
@@ -220,6 +220,8 @@ SUBMISSIONS_RESULTS_DIR = output_dir
 EVALUATOR_DOCKER_IMAGE = "quay.io/yuvipanda/evaluator-harness:latest"
 EVALUATOR_DOCKER_CMD = []
 
+# Set to true to disable network access from inside the container started by evaluator
+EVALUATOR_DOCKER_DISABLE_NETWORK = True
 EVALUATOR_DOCKER_EXTRA_BINDS = []
 EVALUATOR_DOCKER_AUTH = {}
 # If you want to use a GCP Artifact Registry service key, use the following config:

--- a/comptest/web/management/commands/evaluator.py
+++ b/comptest/web/management/commands/evaluator.py
@@ -70,6 +70,8 @@ class DockerEvaluator:
             host_config["CpuQuota"] = int(
                 settings.EVALUATOR_DOCKER_CONTAINER_CPU_LIMIT * host_config["CpuPeriod"]
             )
+        if settings.EVALUATOR_DOCKER_DISABLE_NETWORK:
+            host_config["NetworkMode"] = "none"
         container = await self.docker.containers.create(
             config={
                 "Image": self.image,


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/unnamed-thingity-thing/issues/126