### PR TITLE
Allow setting memory limit for evaluator container

### DIFF
--- a/comptest/comptest/settings.py
+++ b/comptest/comptest/settings.py
@@ -234,6 +234,8 @@ EVALUATOR_DOCKER_AUTH = {}
 
 # Max number of CPUs allowed for the evaluator
 EVALUATOR_DOCKER_CONTAINER_CPU_LIMIT = 2
+# Max memory (in bytes) allowed for the evaluator container
+EVALUATOR_DOCKER_CONTAINER_MEMORY_LIMIT = 2 * 1024 * 1024 * 1024
 
 ## Site specific display settings
 SITE_NAME = ""

--- a/comptest/web/management/commands/evaluator.py
+++ b/comptest/web/management/commands/evaluator.py
@@ -70,6 +70,8 @@ class DockerEvaluator:
             host_config["CpuQuota"] = int(
                 settings.EVALUATOR_DOCKER_CONTAINER_CPU_LIMIT * host_config["CpuPeriod"]
             )
+        if settings.EVALUATOR_DOCKER_CONTAINER_MEMORY_LIMIT:
+            host_config["Memory"] = settings.EVALUATOR_DOCKER_CONTAINER_MEMORY_LIMIT
         if settings.EVALUATOR_DOCKER_DISABLE_NETWORK:
             host_config["NetworkMode"] = "none"
         container = await self.docker.containers.create(


### PR DESCRIPTION
Fixes https://github.com/2i2c-org/unnamed-thingity-thing/issues/113