### PR TITLE
Handle missing containers better

### DIFF
--- a/comptest/web/management/commands/evaluator.py
+++ b/comptest/web/management/commands/evaluator.py
@@ -100,7 +100,12 @@ class DockerEvaluator:
         }
 
     async def is_still_running(self, state: dict) -> bool:
-        container = await self.docker.containers.get(container_id=state["container_id"])
+        try:
+            container = await self.docker.containers.get(container_id=state["container_id"])
+        except aiodocker.DockerError as e:
+            if e.status == 404:
+                return False
+            raise
         return container["State"].get("Status") == "running"
 
     async def get_result(self, state: dict) -> dict:

--- a/comptest/web/management/commands/evaluator.py
+++ b/comptest/web/management/commands/evaluator.py
@@ -101,7 +101,9 @@ class DockerEvaluator:
 
     async def is_still_running(self, state: dict) -> bool:
         try:
-            container = await self.docker.containers.get(container_id=state["container_id"])
+            container = await self.docker.containers.get(
+                container_id=state["container_id"]
+            )
         except aiodocker.DockerError as e:
             if e.status == 404:
                 return False


### PR DESCRIPTION
If the dind container is killed and restarted, losing all state, while a evaluation was running, docker API returns a 404. Handle that gracefully.