### PR TITLE
🚚 Move published helm chart to 2i2c-org/frx-challenges-helm-chart

### DIFF
--- a/chartpress.yaml
+++ b/chartpress.yaml
@@ -20,15 +20,15 @@
 # https://github.com/jupyterhub/chartpress
 #
 charts:
-  - name: unnamed
+  - name: frx-challenges
     chartPath: helm-chart
     imagePrefix: quay.io/2i2c/
     # Set dev version by taking latest tag and incrementing patch
     baseVersion: patch
 
     repo:
-      git: 2i2c-org/unnamed-thingity-thing
-      published: https://2i2c.org/unnamed-thingity-thing/
+      git: 2i2c-org/frx-challenges-helm-chart
+      published: https://2i2c.org/frx-challenges-helm-chart/
 
     images:
       unnamed:


### PR DESCRIPTION
Related to #150.

I would like to host MyST docs on GH-pages but the Helm Chart is currently being published to https://2i2c.org/unnamed-thingity-thing/, so I am moving this to https://2i2c.org/frx-challenges-helm chart/ ([GH repo](https://github.com/2i2c-org/frx-challenges-helm-chart/))